### PR TITLE
Refactor of SignDataUtility to simplify method signature

### DIFF
--- a/CardanoSharp.Wallet/CIPs/CIP30/Extensions/Models/CoseSign1Extensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP30/Extensions/Models/CoseSign1Extensions.cs
@@ -1,64 +1,60 @@
 ﻿using CardanoSharp.Wallet.CIPs.CIP30.Models;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Extensions.Models;
-using CardanoSharp.Wallet.Utilities;
 using PeterO.Cbor2;
 using System;
 
 namespace CardanoSharp.Wallet.CIPs.CIP30.Extensions.Models
 {
-	public static class CoseSign1Extensions
-	{
-		public static CoseSign1 GetCoseSign1(this CBORObject coseSign1Cbor)
-		{
-			//validation
-			if (coseSign1Cbor == null)
-			{
-				throw new ArgumentNullException(nameof(coseSign1Cbor));
-			}
-			if (coseSign1Cbor.Type != CBORType.Array)
-			{
-				throw new ArgumentException($"{nameof(coseSign1Cbor)} is not expected type CBORType.Array");
-			}
-			if (coseSign1Cbor.Count != 4)
-			{
-				throw new ArgumentException($"{nameof(coseSign1Cbor)} does not contain expected 4 keys");
-			}
-			if (coseSign1Cbor[1].Type != CBORType.Map)
-			{
-				throw new ArgumentException($"{nameof(coseSign1Cbor)}[1] 'headers' is not expected type CBORType.Map");
-			}
-			if (!coseSign1Cbor[1].ContainsKey("hashed"))
-			{
-				throw new ArgumentException($"{nameof(coseSign1Cbor)}[1] 'headers' does not contain mandatory header 'hashed'");
-			}
+    public static class CoseSign1Extensions
+    {
+        public static CoseSign1 GetCoseSign1(this CBORObject coseSign1Cbor)
+        {
+            //validation
+            if (coseSign1Cbor == null)
+            {
+                throw new ArgumentNullException(nameof(coseSign1Cbor));
+            }
+            if (coseSign1Cbor.Type != CBORType.Array)
+            {
+                throw new ArgumentException($"{nameof(coseSign1Cbor)} is not expected type CBORType.Array");
+            }
+            if (coseSign1Cbor.Count != 4)
+            {
+                throw new ArgumentException($"{nameof(coseSign1Cbor)} does not contain expected 4 keys");
+            }
+            if (coseSign1Cbor[1].Type != CBORType.Map)
+            {
+                throw new ArgumentException($"{nameof(coseSign1Cbor)}[1] 'headers' is not expected type CBORType.Map");
+            }
+            if (!coseSign1Cbor[1].ContainsKey("hashed"))
+            {
+                throw new ArgumentException($"{nameof(coseSign1Cbor)}[1] 'headers' does not contain mandatory header 'hashed'");
+            }
 
-			var payload = (string)coseSign1Cbor[2].DecodeValueByCborType();
-			var sig = (string)coseSign1Cbor[3].DecodeValueByCborType();
-			bool hashed = (bool)coseSign1Cbor[1]["hashed"].DecodeValueByCborType();
-			string? hashedPayload = null;
-			if (hashed)
-				hashedPayload = HashUtility.Blake2b224(payload.HexToByteArray()).ToStringHex();
-			var headers = coseSign1Cbor[0].ToObject<byte[]>();
+            var payload = (string)coseSign1Cbor[2].DecodeValueByCborType();
+            var sig = (string)coseSign1Cbor[3].DecodeValueByCborType();
+            bool hashed = (bool)coseSign1Cbor[1]["hashed"].DecodeValueByCborType();
+            
+            var headers = coseSign1Cbor[0].ToObject<byte[]>();
 
-			return new CoseSign1()
-			{
-				Signature = sig.HexToByteArray(),
-				Payload = payload.HexToByteArray(),
-				Hashed = hashed,
-				PayloadHash = hashedPayload?.HexToByteArray(),
-				Headers = headers
-			};
-		}
+            return new CoseSign1()
+            {
+                Signature = sig.HexToByteArray(),
+                Payload = payload.HexToByteArray(),
+                Hashed = hashed,
+                Headers = headers
+            };
+        }
 
-		public static byte[] GetSigStructure(this CoseSign1 coseSign1)
-		{
-			return CBORObject.NewArray()
-				.Add("Signature1")
-				.Add(coseSign1.Headers)
-				.Add(Array.Empty<byte>())
-				.Add(coseSign1.GetPayload())
-				.EncodeToBytes();
-		}
-	}
+        public static byte[] GetSigStructure(this CoseSign1 coseSign1)
+        {
+            return CBORObject.NewArray()
+                .Add("Signature1")
+                .Add(coseSign1.Headers)
+                .Add(Array.Empty<byte>())
+                .Add(coseSign1.GetPayload())
+                .EncodeToBytes();
+        }
+    }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP30/Models/CoseSign1.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP30/Models/CoseSign1.cs
@@ -10,12 +10,8 @@
 
 		public bool Hashed { get; set; } = false;
 
-		public byte[]? PayloadHash { get; set; }
-
 		public byte[] GetPayload()
 		{
-			if (Hashed && PayloadHash != null)
-				return PayloadHash;
 			return Payload;
 		}
 	}

--- a/CardanoSharp.Wallet/Utilities/SignDataUtility.cs
+++ b/CardanoSharp.Wallet/Utilities/SignDataUtility.cs
@@ -10,34 +10,77 @@ namespace CardanoSharp.Wallet.Utilities
 {
     public static class SignDataUtility
     {
-        public static DataSignature SignData(ICoseSigner coseSigner, PrivateKey rootKey, string payload,
-            int addressIndex, NetworkType networkType = NetworkType.Mainnet)
+        /// <summary>
+        /// Sign Payload
+        /// https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0008/
+        /// </summary>
+        /// <param name="coseSigner">An instance of CoseSigner</param>
+        /// <param name="payload">String value</param>
+        /// <param name="stake">Stake public address</param>
+        /// <param name="payment">Payment address private key</param>
+        /// <param name="networkType">Cardano network.</param>
+        /// <param name="hash">Hash payload</param>
+        /// <returns></returns>
+        public static DataSignature SignData(ICoseSigner coseSigner, string payload,
+            PublicKey stake, PrivateKey payment,
+            NetworkType networkType = NetworkType.Mainnet,
+            bool hash = false)
         {
-            // stake 
-            var (_, sPub) = rootKey.GetKeyPairFromPath($"m/1852'/1815'/0'/2/0", false);
+            var aPub = payment.GetPublicKey(false);
+            var address = AddressUtility.GetBaseAddress(aPub, stake, networkType);
 
-            // payment address at index
-            var (aPri, aPub) = rootKey.GetKeyPairFromPath($"m/1852'/1815'/0'/0/{addressIndex}", false);
+            var payloadBytes = payload.ToBytes();
+            if (hash)
+            {
+                // reference: https://github.com/gitmachtl/cardano-signer/blob/e792768944c8f8d5244a418472cc14028e95aa27/src/cardano-signer.js#L605
+                payloadBytes = HashUtility.Blake2b224(payloadBytes);
+            }
+            
+            var coseSign1 = coseSigner.BuildCoseSign1(
+                payloadBytes,
+                payment,
+                address: address.GetBytes(),
+                hashed: hash);
 
-            var address = AddressUtility.GetBaseAddress(aPub, sPub, networkType);
-
-            var coseSign1 = coseSigner.BuildCoseSign1(payload.ToBytes(), aPri, address: address.GetBytes());
-
-            var key = new CIPs.CIP8.Models
-                    .CoseKey(
-                        KeyType.Okp,
-                        AlgorithmId.EdDsa,
-                        CurveType.Ed25519,
-                        verificationKey: aPub.Key)
-                .GetCbor()
-                .EncodeToBytes();
-
+            var key = new CIPs.CIP8.Models.CoseKey(
+                KeyType.Okp,
+                AlgorithmId.EdDsa,
+                CurveType.Ed25519,
+                verificationKey: aPub.Key);
 
             return new()
             {
                 Signature = coseSign1.GetCbor().EncodeToBytes().ToStringHex(),
-                Key = key.ToStringHex()
+                Key = key.GetCbor().EncodeToBytes().ToStringHex()
             };
+        }
+
+        /// <summary>
+        /// Sign Payload
+        /// https://developers.cardano.org/docs/governance/cardano-improvement-proposals/cip-0008/
+        /// </summary>
+        /// <param name="coseSigner">An instance of CoseSigner</param>
+        /// <param name="payload">String value</param>
+        /// <param name="privateKey">Private key. eg: root or account private key.</param>
+        /// <param name="stakePath">Derivation path to resolve stake keys</param>
+        /// <param name="paymentPath">Derivation path to resolve signing payment keys</param>
+        /// <param name="networkType">Cardano network.</param>
+        /// <param name="hash">Hash payload</param>
+        /// <returns></returns>
+        public static DataSignature SignData(ICoseSigner coseSigner, string payload,
+            PrivateKey privateKey,
+            string stakePath = "m/1852'/1815'/0'/2/0",
+            string paymentPath = "m/1852'/1815'/0'/0/0",
+            NetworkType networkType = NetworkType.Mainnet,
+            bool hash = false)
+        {
+            // stake 
+            var (_, sPub) = privateKey.GetKeyPairFromPath(stakePath, false);
+
+            // payment
+            var (aPri, _) = privateKey.GetKeyPairFromPath(paymentPath, false);
+
+            return SignData(coseSigner, payload, sPub, aPri, networkType, hash);
         }
     }
 }


### PR DESCRIPTION
Fixed an issue in CIP30 GetCoseSign1, handling hashed payload incorrectly